### PR TITLE
fix: Fix height for `.topbar__logo-link` on Firefox

### DIFF
--- a/src/styles/elements/_topbar.css
+++ b/src/styles/elements/_topbar.css
@@ -22,7 +22,7 @@
         --topbar-before-z-index: 0;
 
         --topbar-logo-link-grid-area: logo;
-        --topbar-logo-link-height: calc(100% - var(--spacing-normal));
+        --topbar-logo-link-height: calc(var(--topbar-height) - var(--spacing-normal));
         --topbar-logo-link-max-height: calc(100% - var(--spacing-normal));
         --topbar-logo-link-width: fit-content;
         --topbar-logo-link-z-index: 1;


### PR DESCRIPTION
First occured on https://www.palatina.de/
(Deactivate inline CSS on `.topbar__logo-link` when viewing the page in Firefox to see the issue.)

The same problem now occurs on https://www.t3cb.de/:
Previous:
<img width="371" height="294" alt="grafik" src="https://github.com/user-attachments/assets/007558d0-7572-4521-bb88-390385123684" />
After:
<img width="319" height="235" alt="grafik" src="https://github.com/user-attachments/assets/c0247413-8ab0-4f75-9238-b95447371829" />

The change doesn't seem to bear any consequences on mobile, Chrome, Safari.