### PR TITLE
refactor(content-card): reassign font color variable for nested text

### DIFF
--- a/src/stories/02-elements/content-card-with-text/content-card-with-text.docs.mdx
+++ b/src/stories/02-elements/content-card-with-text/content-card-with-text.docs.mdx
@@ -21,7 +21,7 @@ For more information please check the documentation for the `toujou-grid`, `touj
 
             <div class="content-card__content">
                 <h3 class="content-card__title">Lorem Ipsum</h3>
-                <p class=" content-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+                <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p></div>
                 <span class="content-card__button">
                     <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                     more

--- a/src/stories/02-elements/content-card-with-text/content-card-with-text.stories.ts
+++ b/src/stories/02-elements/content-card-with-text/content-card-with-text.stories.ts
@@ -38,7 +38,7 @@ function renderCardColumn() {
 
                 <div class="content-card__content">
                     <h3 class="content-card__title">Lorem Ipsum</h3>
-                    <p class=" content-card__text">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p></div>
                     <span class="content-card__button">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         more

--- a/src/stories/02-elements/content-card/content-card-horizontal.stories.ts
+++ b/src/stories/02-elements/content-card/content-card-horizontal.stories.ts
@@ -68,7 +68,7 @@ const Template: StoryFn<ContentCardStoryProps> = (args: ContentCardStoryProps) =
             </figure>
             <div class="content-card__content">
                 <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
 
                 ${args.hasLink ? `
                     <span class="content-card__button">

--- a/src/stories/02-elements/content-card/content-card-vertical.stories.ts
+++ b/src/stories/02-elements/content-card/content-card-vertical.stories.ts
@@ -66,9 +66,9 @@ const Template: StoryFn<ContentCardStoryProps> = (args: ContentCardStoryProps) =
             <div class="content-card__content">
                 <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
                 ${i == 2 ? `
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                 ` : `
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                 `}
 
                 ${args.hasLink ? `

--- a/src/stories/02-elements/content-card/content-card.docs.mdx
+++ b/src/stories/02-elements/content-card/content-card.docs.mdx
@@ -15,7 +15,7 @@ The link on the content card is optional. If there is a link we render `<a class
         </figure>
         <div class="content-card__content">
             <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-            <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+            <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
         </div>
     </toujou-content-card>
 </toujou-content-card-grid>
@@ -30,7 +30,7 @@ The link on the content card is optional. If there is a link we render `<a class
         </figure>
         <div class="content-card__content">
             <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-            <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+            <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
             <span class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                 <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                 zur Beschreibung

--- a/src/stories/03-pages/event/event-with-content.stories.ts
+++ b/src/stories/03-pages/event/event-with-content.stories.ts
@@ -214,7 +214,7 @@ const Template: StoryFn<EvenWithContentProps> = (args: EvenWithContentProps) => 
                         </figure>
                         <div class="content-card__content">
                             <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                            <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                            <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                             <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                                 <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                                 zur Beschreibung
@@ -228,7 +228,7 @@ const Template: StoryFn<EvenWithContentProps> = (args: EvenWithContentProps) => 
                         </figure>
                         <div class="content-card__content">
                             <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                            <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                            <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                             <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                                 <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                                 zur Beschreibung

--- a/src/stories/04-tests/chapter/chapter.stories.ts
+++ b/src/stories/04-tests/chapter/chapter.stories.ts
@@ -346,7 +346,7 @@ const Template = () => {
             <h3 class="content-card__title">Lorem Ipsum</h3>
 
 
-            <p class=" content-card__text">Mit der Containerabfragespezifikation können Sie auch die Stilwerte eines übergeordneten Containers abfragen. Dies ist derzeit teilweise in Chrome 111 implementiert. Dort können Sie benutzerdefinierte CSS-Eigenschaften verwenden, um Containerstile anzuwenden.</p>
+            <div class="content-card__text"><p>Mit der Containerabfragespezifikation können Sie auch die Stilwerte eines übergeordneten Containers abfragen. Dies ist derzeit teilweise in Chrome 111 implementiert. Dort können Sie benutzerdefinierte CSS-Eigenschaften verwenden, um Containerstile anzuwenden.</p></div>
 
 
             <span class="content-card__button" aria-hidden="true">
@@ -398,7 +398,7 @@ const Template = () => {
             <h3 class="content-card__title">Title</h3>
 
 
-            <p class=" content-card__text">Mit der Containerabfragespezifikation können Sie auch die Stilwerte eines übergeordneten Containers abfragen. Dies ist derzeit teilweise in Chrome 111 implementiert. Dort können Sie benutzerdefinierte CSS-Eigenschaften verwenden, um Containerstile anzuwenden.</p>
+            <div class="content-card__text"><p>Mit der Containerabfragespezifikation können Sie auch die Stilwerte eines übergeordneten Containers abfragen. Dies ist derzeit teilweise in Chrome 111 implementiert. Dort können Sie benutzerdefinierte CSS-Eigenschaften verwenden, um Containerstile anzuwenden.</p></div>
 
 
             <span class="content-card__button" aria-hidden="true">
@@ -446,7 +446,7 @@ const Template = () => {
             <h3 class="content-card__title">Title</h3>
 
 
-            <p class=" content-card__text">Mit der Containerabfragespezifikation können Sie auch die Stilwerte eines übergeordneten Containers abfragen. Dies ist derzeit teilweise in Chrome 111 implementiert. Dort können Sie benutzerdefinierte CSS-Eigenschaften verwenden, um Containerstile anzuwenden.</p>
+            <div class="content-card__text"><p>Mit der Containerabfragespezifikation können Sie auch die Stilwerte eines übergeordneten Containers abfragen. Dies ist derzeit teilweise in Chrome 111 implementiert. Dort können Sie benutzerdefinierte CSS-Eigenschaften verwenden, um Containerstile anzuwenden.</p></div>
 
 
             <span class="content-card__button" aria-hidden="true">
@@ -497,7 +497,7 @@ const Template = () => {
             <h3 class="content-card__title">Lorem Ipsum</h3>
 
 
-            <p class=" content-card__text">Mit der Containerabfragespezifikation können Sie auch die Stilwerte eines übergeordneten Containers abfragen. Dies ist derzeit teilweise in Chrome 111 implementiert. Dort können Sie benutzerdefinierte CSS-Eigenschaften verwenden, um Containerstile anzuwenden.</p>
+            <div class="content-card__text"><p>Mit der Containerabfragespezifikation können Sie auch die Stilwerte eines übergeordneten Containers abfragen. Dies ist derzeit teilweise in Chrome 111 implementiert. Dort können Sie benutzerdefinierte CSS-Eigenschaften verwenden, um Containerstile anzuwenden.</p></div>
 
 
     </div>

--- a/src/stories/04-tests/content-cards-pages/content-card-mixed-page.stories.ts
+++ b/src/stories/04-tests/content-cards-pages/content-card-mixed-page.stories.ts
@@ -56,7 +56,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -80,7 +80,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -104,7 +104,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -118,7 +118,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -132,7 +132,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -146,7 +146,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -170,7 +170,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -184,7 +184,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung

--- a/src/stories/04-tests/content-cards-pages/content-cards-horizontal-page.stories.ts
+++ b/src/stories/04-tests/content-cards-pages/content-cards-horizontal-page.stories.ts
@@ -56,7 +56,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -70,7 +70,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -94,7 +94,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung

--- a/src/stories/04-tests/content-cards-pages/content-cards-vertical-page.stories.ts
+++ b/src/stories/04-tests/content-cards-pages/content-cards-vertical-page.stories.ts
@@ -56,7 +56,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -70,7 +70,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -84,7 +84,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -98,59 +98,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
-                    <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
-                        <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
-                        zur Beschreibung
-                    </a>
-                </div>
-            </toujou-content-card>
-        </toujou-content-card-grid>
-
-        <toujou-text-block class="text-block" text-blocks-column-count="1">
-            <toujou-text-block-column class="text-block-column">
-                <div class="text-block__content">
-                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-                </div>
-            </toujou-text-block-column>
-        </toujou-text-block>
-
-        <toujou-content-card-grid class="content-card-grid">
-            <toujou-content-card class="content-card" href="#" card-variant="default" card-direction="vertical">
-                <figure class="content-card__figure">
-                    <img src="https://picsum.photos/640/640" alt="beautiful image" class="content-card__image">
-                </figure>
-                <div class="content-card__content">
-                    <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
-                    <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
-                        <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
-                        zur Beschreibung
-                    </a>
-                </div>
-            </toujou-content-card>
-
-            <toujou-content-card class="content-card" href="#" card-variant="default" card-direction="vertical">
-                <figure class="content-card__figure">
-                    <img src="https://picsum.photos/640/640" alt="beautiful image" class="content-card__image">
-                </figure>
-                <div class="content-card__content">
-                    <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
-                    <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
-                        <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
-                        zur Beschreibung
-                    </a>
-                </div>
-            </toujou-content-card>
-
-            <toujou-content-card class="content-card" href="#" card-variant="default" card-direction="vertical">
-                <figure class="content-card__figure">
-                    <img src="https://picsum.photos/640/640" alt="beautiful image" class="content-card__image">
-                </figure>
-                <div class="content-card__content">
-                    <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -174,7 +122,7 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -188,7 +136,21 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
+                    <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
+                        <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
+                        zur Beschreibung
+                    </a>
+                </div>
+            </toujou-content-card>
+
+            <toujou-content-card class="content-card" href="#" card-variant="default" card-direction="vertical">
+                <figure class="content-card__figure">
+                    <img src="https://picsum.photos/640/640" alt="beautiful image" class="content-card__image">
+                </figure>
+                <div class="content-card__content">
+                    <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung
@@ -212,7 +174,45 @@ const Template = () => {
                 </figure>
                 <div class="content-card__content">
                     <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
-                    <p class="content-card__text">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
+                    <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
+                        <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
+                        zur Beschreibung
+                    </a>
+                </div>
+            </toujou-content-card>
+
+            <toujou-content-card class="content-card" href="#" card-variant="default" card-direction="vertical">
+                <figure class="content-card__figure">
+                    <img src="https://picsum.photos/640/640" alt="beautiful image" class="content-card__image">
+                </figure>
+                <div class="content-card__content">
+                    <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
+                    <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
+                        <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
+                        zur Beschreibung
+                    </a>
+                </div>
+            </toujou-content-card>
+        </toujou-content-card-grid>
+
+        <toujou-text-block class="text-block" text-blocks-column-count="1">
+            <toujou-text-block-column class="text-block-column">
+                <div class="text-block__content">
+                    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+                </div>
+            </toujou-text-block-column>
+        </toujou-text-block>
+
+        <toujou-content-card-grid class="content-card-grid">
+            <toujou-content-card class="content-card" href="#" card-variant="default" card-direction="vertical">
+                <figure class="content-card__figure">
+                    <img src="https://picsum.photos/640/640" alt="beautiful image" class="content-card__image">
+                </figure>
+                <div class="content-card__content">
+                    <h3 class="content-card__title">Eine etwas längere Headline über zwei Zeilen</h3>
+                    <div class="content-card__text"><p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Assumenda consectetur excepturi officiis.</p></div>
                     <a href="#" class="content-card__button" button-variant="primary" button-type="ghost" button-size="normal">
                         <toujou-icon class="icon" icon-name="arrow-right" icon-color="primary"></toujou-icon>
                         zur Beschreibung

--- a/src/stories/04-tests/test-page/test-page.stories.ts
+++ b/src/stories/04-tests/test-page/test-page.stories.ts
@@ -389,13 +389,13 @@ const Template = () => {
             <h3 class="content-card__title">Für ALLE gut</h3>
 
 
-            <p class=" content-card__text">ALLE profitieren von leicht zugänglichen Angeboten:</p>
-<p class=" content-card__text">Nicht nur an Handicaps denken</p>
-<p class=" content-card__text">- schlechte Internetverbindung oder technische Ausstattung</p>
-<p class=" content-card__text">- Kinder, &nbsp;alte Menschen</p>
-<p class=" content-card__text">- weniger erfahrene Menschen</p>
-<p class=" content-card__text">- Suchmaschinen</p>
-<p class=" content-card__text">- und vieles mehr</p>
+            <div class="content-card__text"><p>ALLE profitieren von leicht zugänglichen Angeboten:</p></div>
+<div class="content-card__text"><p>Nicht nur an Handicaps denken</p></div>
+<div class="content-card__text"><p>- schlechte Internetverbindung oder technische Ausstattung</p></div>
+<div class="content-card__text"><p>- Kinder, &nbsp;alte Menschen</p></div>
+<div class="content-card__text"><p>- weniger erfahrene Menschen</p></div>
+<div class="content-card__text"><p>- Suchmaschinen</p></div>
+<div class="content-card__text"><p>- und vieles mehr</p></div>
 
 
     </div>
@@ -432,10 +432,10 @@ const Template = () => {
             <h3 class="content-card__title">VERBESSERUNG als Ziel</h3>
 
 
-            <p class=" content-card__text">Verbesserungen auf vielen Ebenen:</p>
-<p class=" content-card__text">- Pagespeed</p>
-<p class=" content-card__text">- moderne Konzepte</p>
-<p class=" content-card__text">- …..</p>
+            <div class="content-card__text"><p>Verbesserungen auf vielen Ebenen:</p></div>
+<div class="content-card__text"><p>- Pagespeed</p></div>
+<div class="content-card__text"><p>- moderne Konzepte</p></div>
+<div class="content-card__text"><p>- …..</p></div>
 
 
 
@@ -475,8 +475,8 @@ const Template = () => {
             <h3 class="content-card__title">ecxellente Basis für CUSTOMIZATION</h3>
 
 
-            <p class=" content-card__text">- wenn die zukünftigen Anpassungen schon mitgedacht sind</p>
-<p class=" content-card__text">- …</p>
+            <div class="content-card__text"><p>- wenn die zukünftigen Anpassungen schon mitgedacht sind</p></div>
+<div class="content-card__text"><p>- …</p></div>
 
 
     </div>

--- a/src/styles/elements/_content-card.css
+++ b/src/styles/elements/_content-card.css
@@ -105,7 +105,7 @@
     }
 
     .content-card__text {
-        color: var(--content-card-text-color);
+        --color-font: var(--content-card-text-color);
     }
 
     .content-card__text:first-child {

--- a/src/tests/content-card/e2e/content-card-horizontal.cy.ts
+++ b/src/tests/content-card/e2e/content-card-horizontal.cy.ts
@@ -26,7 +26,7 @@ describe('content card - horizontal', () => {
         cy.get('.content-card:first-child .content-card__figure .content-card__image').should('exist');
         cy.get('.content-card:first-child .content-card__content').should('exist');
         cy.get('.content-card:first-child .content-card__content .content-card__title').should('exist');
-        cy.get('.content-card:first-child .content-card__content .content-card__text').should('exist');
+        cy.get('.content-card:first-child .content-card__content .content-card__text p').should('exist');
     });
 
     it('card has correct attributes', () => {
@@ -65,10 +65,10 @@ describe('content card - horizontal', () => {
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorFontDark);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'margin', `0px 0px ${tokens.spacing.normal}`);
 
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'margin', `${tokens.spacing.normal} 0px 0px`);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'font-family', tokens.type.fontFamily.text);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'font-size', tokens.type.size.normal);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorFont);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'margin', `${tokens.spacing.normal} 0px 0px`);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'font-family', tokens.type.fontFamily.text);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'font-size', tokens.type.size.normal);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorFont);
     });
 });
 
@@ -82,7 +82,7 @@ describe('content card - horizontal - primary', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'primary');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorPrimary);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });
@@ -97,7 +97,7 @@ describe('content card - horizontal - secondary', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'secondary');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorSecondary);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });
@@ -112,7 +112,7 @@ describe('content card - horizontal - inverted', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'inverted');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorFont);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });

--- a/src/tests/content-card/e2e/content-card-horizontal.mobile.cy.ts
+++ b/src/tests/content-card/e2e/content-card-horizontal.mobile.cy.ts
@@ -27,7 +27,7 @@ describe('content card - horizontal [mobile]', () => {
         cy.get('.content-card:first-child .content-card__figure .content-card__image').should('exist');
         cy.get('.content-card:first-child .content-card__content').should('exist');
         cy.get('.content-card:first-child .content-card__content .content-card__title').should('exist');
-        cy.get('.content-card:first-child .content-card__content .content-card__text').should('exist');
+        cy.get('.content-card:first-child .content-card__content .content-card__text p').should('exist');
     });
 
     it('card has correct attributes', () => {
@@ -66,10 +66,10 @@ describe('content card - horizontal [mobile]', () => {
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorFontDark);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'margin', `0px 0px ${tokens.spacing.normal}`);
 
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'margin', `${tokens.spacing.normal} 0px 0px`);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'font-family', tokens.type.fontFamily.text);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'font-size', tokens.type.size.normal);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorFont);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'margin', `${tokens.spacing.normal} 0px 0px`);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'font-family', tokens.type.fontFamily.text);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'font-size', tokens.type.size.normal);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorFont);
     });
 });
 
@@ -84,7 +84,7 @@ describe('content card - horizontal - primary [mobile]', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'primary');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorPrimary);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });
@@ -100,7 +100,7 @@ describe('content card - horizontal - secondary [mobile]', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'secondary');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorSecondary);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });
@@ -116,7 +116,7 @@ describe('content card - horizontal - inverted [mobile]', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'inverted');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorFont);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });

--- a/src/tests/content-card/e2e/content-card-vertical.cy.ts
+++ b/src/tests/content-card/e2e/content-card-vertical.cy.ts
@@ -26,7 +26,7 @@ describe('content card - vertical', () => {
         cy.get('.content-card:first-child .content-card__figure .content-card__image').should('exist');
         cy.get('.content-card:first-child .content-card__content').should('exist');
         cy.get('.content-card:first-child .content-card__content .content-card__title').should('exist');
-        cy.get('.content-card:first-child .content-card__content .content-card__text').should('exist');
+        cy.get('.content-card:first-child .content-card__content .content-card__text p').should('exist');
     });
 
     it('card has correct attributes', () => {
@@ -65,10 +65,10 @@ describe('content card - vertical', () => {
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorFontDark);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'margin', `0px 0px ${tokens.spacing.normal}`);
 
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'margin', `${tokens.spacing.normal} 0px 0px`);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'font-family', tokens.type.fontFamily.text);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'font-size', tokens.type.size.normal);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorFont);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'margin', `${tokens.spacing.normal} 0px 0px`);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'font-family', tokens.type.fontFamily.text);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'font-size', tokens.type.size.normal);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorFont);
     });
 });
 
@@ -82,7 +82,7 @@ describe('content card - vertical - primary', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'primary');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorPrimary);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });
@@ -97,7 +97,7 @@ describe('content card - vertical - secondary', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'secondary');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorSecondary);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });
@@ -112,7 +112,7 @@ describe('content card - vertical - inverted', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'inverted');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorFont);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });

--- a/src/tests/content-card/e2e/content-card-vertical.mobile.cy.ts
+++ b/src/tests/content-card/e2e/content-card-vertical.mobile.cy.ts
@@ -27,7 +27,7 @@ describe('content card - vertical [mobile]', () => {
         cy.get('.content-card:first-child .content-card__figure .content-card__image').should('exist');
         cy.get('.content-card:first-child .content-card__content').should('exist');
         cy.get('.content-card:first-child .content-card__content .content-card__title').should('exist');
-        cy.get('.content-card:first-child .content-card__content .content-card__text').should('exist');
+        cy.get('.content-card:first-child .content-card__content .content-card__text p').should('exist');
     });
 
     it('card has correct attributes', () => {
@@ -66,10 +66,10 @@ describe('content card - vertical [mobile]', () => {
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorFontDark);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'margin', `0px 0px ${tokens.spacing.normal}`);
 
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'margin', `${tokens.spacing.normal} 0px 0px`);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'font-family', tokens.type.fontFamily.text);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'font-size', tokens.type.size.normal);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorFont);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'margin', `${tokens.spacing.normal} 0px 0px`);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'font-family', tokens.type.fontFamily.text);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'font-size', tokens.type.size.normal);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorFont);
     });
 });
 
@@ -84,7 +84,7 @@ describe('content card - vertical - primary [mobile]', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'primary');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorPrimary);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });
@@ -100,7 +100,7 @@ describe('content card - vertical - secondary [mobile]', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'secondary');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorSecondary);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });
@@ -116,7 +116,7 @@ describe('content card - vertical - inverted [mobile]', () => {
         cy.get('toujou-content-card').invoke('attr', 'card-variant').should('eq', 'inverted');
         cy.get('.content-card:first-child').should('have.css', 'background-color', colors.colorFont);
         cy.get('.content-card:first-child .content-card__title').should('have.css', 'color', colors.colorBg);
-        cy.get('.content-card:first-child .content-card__text').should('have.css', 'color', colors.colorBg);
+        cy.get('.content-card:first-child .content-card__text p').should('have.css', 'color', colors.colorBg);
 
     });
 });


### PR DESCRIPTION
Updates .content-card__text to override the `--color-font` variable, ensuring nested paragraphs inherit the correct theme color after the markup restructuring.